### PR TITLE
Fix screenshot docs from mobile

### DIFF
--- a/docs/using-screenshot/index.md
+++ b/docs/using-screenshot/index.md
@@ -23,17 +23,17 @@ Every website screenshot image files will be cached on the CDN for 1 month.
 
 ## Parameters
 
-### device=mobile
-
-Get a mobile version.
-
-`/screenshot/device=mobile/:url`
-
 ### full=true
 
 Get a full page version.
 
 `/screenshot/full=true/:url`
+
+### mobile (path)
+
+Get a mobile version.
+
+`/screenshot/mobile/:url`
 
 ### pdf (path)
 

--- a/docs/using-screenshot/index.md
+++ b/docs/using-screenshot/index.md
@@ -41,18 +41,12 @@ Getting PDF version.
 
 `/screenshot/pdf/:url`
 
-### Combine params
-
-Params can be combined using commas and after /screenshot/ path.
-
-`/screenshot/device=mobile,full=true/:url`
-
 ## Live Demo
 
 `/screenshot/dev.to`
 
 ![Screenshot](https://cdn.statically.io/screenshot/dev.to)
 
-`/screenshot/device=mobile/dev.to`
+`/screenshot/mobile/dev.to`
 
-![Screenshot (mobile)](https://cdn.statically.io/screenshot/device=mobile/dev.to)
+![Screenshot (mobile)](https://cdn.statically.io/screenshot/mobile/dev.to)


### PR DESCRIPTION
In the screenshot repo, the screenshot repo is using /screenshot/mobile endpoint, buts /screenshot/device=mobile endpoint seems being used in this repo.
This PR modifies the endpoint and adds some parameter (was going to remove combination notice, but seems there is more queries).